### PR TITLE
readme: fix download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 - Download ChartWerk panel
 ```
-wget https://github.com/chartwerk/grafana-chartwerk-panel/archive/0.1.2.zip
+wget https://github.com/chartwerk/grafana-chartwerk-app/archive/0.1.2.zip
 ```
 
 - Unpack downloaded files


### PR DESCRIPTION
This PR fixes the plugin download link in readme according to https://github.com/chartwerk/grafana-chartwerk-app/issues/52